### PR TITLE
fix: typos, stage domain dependency injection

### DIFF
--- a/src/modules/characters/characters.entity.ts
+++ b/src/modules/characters/characters.entity.ts
@@ -10,7 +10,7 @@ export class Characters extends BaseEntity {
     type: 'int',
     comment: '스팀 아이디',
   })
-  stream_id: number;
+  steam_id: number;
 
   @Column({
     type: 'bool',
@@ -49,6 +49,6 @@ export class Characters extends BaseEntity {
   ulises!: boolean;
 
   @ManyToOne(() => Users, (users) => users.steam_ids)
-  @JoinColumn({ name: 'stream_id' })
+  @JoinColumn({ name: 'steam_id' })
   users: Users;
 }

--- a/src/modules/clauses/clauses.entity.ts
+++ b/src/modules/clauses/clauses.entity.ts
@@ -10,7 +10,7 @@ export class Clauses extends BaseEntity {
     type: 'int',
     comment: '스팀 아이디',
   })
-  stream_id: number;
+  steam_id: number;
 
   @Column({
     comment: '첫 번째 약관',
@@ -31,6 +31,6 @@ export class Clauses extends BaseEntity {
   third_clause!: boolean;
 
   @ManyToOne(() => Users, (users) => users.steam_ids)
-  @JoinColumn({ name: 'stream_id' })
+  @JoinColumn({ name: 'steam_id' })
   users: Users;
 }

--- a/src/modules/presets/presets.entity.ts
+++ b/src/modules/presets/presets.entity.ts
@@ -60,6 +60,6 @@ export class Presets extends BaseEntity {
   character!: string;
 
   @ManyToOne(() => Users, (users) => users.steam_ids)
-  @JoinColumn({ name: 'stream_id' })
+  @JoinColumn({ name: 'steam_id' })
   users: Users;
 }

--- a/src/modules/presets/presets.module.ts
+++ b/src/modules/presets/presets.module.ts
@@ -13,5 +13,6 @@ import { GlobalValidationPipe } from '@/common/errors/globalValidatiion.pipe';
   imports: [TypeOrmModule.forFeature([Presets])],
   providers: [PresetsService, GlobalHttpExceptionFilter, GlobalValidationPipe],
   controllers: [PresetsController],
+  exports: [PresetsService],
 })
 export class PresetsModule {}

--- a/src/modules/reward_boxes/reward_boxes.entity.ts
+++ b/src/modules/reward_boxes/reward_boxes.entity.ts
@@ -21,8 +21,6 @@ export class Reward_boxes extends BaseEntity {
     type: 'int',
     comment: '스팀 아이디',
   })
-  steam_id: number;
-
   @Column({
     type: 'int',
     comment: '상자 등급',
@@ -62,6 +60,6 @@ export class Reward_boxes extends BaseEntity {
   updated_at!: Date;
 
   @ManyToOne(() => Users, (users) => users.steam_ids)
-  @JoinColumn({ name: 'stream_id' })
+  @JoinColumn({ name: 'steam_id' })
   users: Users;
 }

--- a/src/modules/saint_soul/saint_soul.entity.ts
+++ b/src/modules/saint_soul/saint_soul.entity.ts
@@ -66,6 +66,6 @@ export class Saint_soul extends BaseEntity {
   updated_at!: Date;
 
   @ManyToOne(() => Users, (users) => users.steam_ids)
-  @JoinColumn({ name: 'stream_id' })
+  @JoinColumn({ name: 'steam_id' })
   users: Users;
 }

--- a/src/modules/stages/stages.controller.ts
+++ b/src/modules/stages/stages.controller.ts
@@ -4,23 +4,22 @@ import { StagesService } from './stages.service';
 import { PresetsService } from '../presets/presets.service';
 import { CreateStageDto } from './stages.dto';
 import { ApiOperation } from '@nestjs/swagger';
-import { encrypt } from '@utils/security';
 
 @Controller('stage')
 export class StagesController {
-  constructor(private StagesService: StagesService, private PresetsService: PresetsService) {}
+  constructor(private stagesService: StagesService, private presetsService: PresetsService) {}
 
   @ApiOperation({ summary: '스테이지 시작 시 요청' })
   @Post('/start')
   async createStage(@Body() data: CreateStageDto) {
     console.log('in router :: ', data);
 
-    const stage = await this.StagesService.create({
-      stream_id: data.steam_id,
+    const stage = await this.stagesService.create({
+      steam_id: data.steam_id,
       stage: data.stage,
     });
 
-    const preset = await this.PresetsService.create({
+    const preset = await this.presetsService.create({
       saint_soul_type: data.saint_soul,
       soul1: data.soul.at(0),
       soul2: data.soul.at(1),

--- a/src/modules/stages/stages.entity.ts
+++ b/src/modules/stages/stages.entity.ts
@@ -43,6 +43,6 @@ export class Stages extends BaseEntity {
   created_at!: Date;
 
   @ManyToOne(() => Users, (users) => users.steam_ids)
-  @JoinColumn({ name: 'stream_id' })
+  @JoinColumn({ name: 'steam_id' })
   users: Users;
 }

--- a/src/modules/stages/stages.module.ts
+++ b/src/modules/stages/stages.module.ts
@@ -1,17 +1,18 @@
 import { MiddlewareConsumer, Module, RequestMethod } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { Stages } from './stages.entity';
 import { StagesService } from './stages.service';
 import { StagesController } from './stages.controller';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { DecryptionMiddleware } from './stages.middleware';
+
 import { GlobalHttpExceptionFilter } from '@/common/errors/globalHttpException.filter';
 import { GlobalValidationPipe } from '@/common/errors/globalValidatiion.pipe';
-import { PresetsService } from '../presets/presets.service';
+import { PresetsModule } from '../presets/presets.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Stages])],
-  providers: [StagesService, PresetsService, GlobalHttpExceptionFilter, GlobalValidationPipe],
+  imports: [TypeOrmModule.forFeature([Stages]), PresetsModule],
+  providers: [StagesService, GlobalHttpExceptionFilter, GlobalValidationPipe],
   controllers: [StagesController],
 })
 export class StagesModule {

--- a/src/modules/users/users.dto.ts
+++ b/src/modules/users/users.dto.ts
@@ -2,7 +2,7 @@ import { IsOptional, IsString } from 'class-validator';
 
 export class RegisterDto {
   @IsString()
-  steam_id: string;
+  steam_id: number;
 
   @IsString()
   name: string;


### PR DESCRIPTION
### 앞으로 해야할 일
1. 반드시 실행되는지 체크하기
    - PR에 swagger에서 실행되는 것 이미지 첨부

~2. 다른 table에서 steam_id 없애기~
    ~- User에만 있으면 됨~
3. 코드에 대한 설명 (제가 궁금해서)
아래와 같은 코드가 entity에 있던데 이 부분 궁금합니다. 설명해주세요 :)
```
  @ManyToOne(() => Users, (users) => users.steam_ids)
  @JoinColumn({ name: 'steam_id' })
  users: Users;

  @OneToMany(() => Users, (users) => users.steam_id)
  steam_ids!: Users[];
```

[참고] table create할 때 실행된 쿼리 (nest에서 해준것)
<img src="https://user-images.githubusercontent.com/51700274/233765232-caa4f2f4-0c8d-4d18-8631-113a43b71392.png" width=400 />
<img src="https://user-images.githubusercontent.com/51700274/233765239-baae8ba7-6992-42ca-bf1b-e31834493ac4.png" width=400 />

### 수정한 부분
1. stream_id -> steam_id 오타 수정
2. stage에서 preset service를 사용하기 위한 module import, export