### PR TITLE
feat: add more data table when users regist

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { SaintSoulsModule } from './modules/saint_souls/saint_souls.module';
 import { PresetsModule } from './modules/presets/presets.module';
 import { AssetsModule } from './modules/assets/assets.module';
 import { CharactersModule } from './modules/characters/characters.module';
+import { SoulsModule } from './modules/souls/souls.module';
 
 import { APP_PIPE } from '@nestjs/core';
 
@@ -36,6 +37,7 @@ import { APP_PIPE } from '@nestjs/core';
     UsersModule,
     StagesModule,
     SaintSoulsModule,
+    SoulsModule,
     PresetsModule,
     AssetsModule,
     CharactersModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,11 @@ import { AppService } from './app.service';
 import { MedicinesModule } from '@medicines/medicines.module';
 import { UsersModule } from '@users/users.module';
 import { StagesModule } from './modules/stages/stages.module';
+import { SaintSoulsModule } from './modules/saint_souls/saint_souls.module';
+import { PresetsModule } from './modules/presets/presets.module';
+import { AssetsModule } from './modules/assets/assets.module';
+import { CharactersModule } from './modules/characters/characters.module';
+
 import { APP_PIPE } from '@nestjs/core';
 
 @Module({
@@ -30,6 +35,10 @@ import { APP_PIPE } from '@nestjs/core';
     MedicinesModule,
     UsersModule,
     StagesModule,
+    SaintSoulsModule,
+    PresetsModule,
+    AssetsModule,
+    CharactersModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/modules/assets/assets.controller.spec.ts
+++ b/src/modules/assets/assets.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AssetsController } from './assets.controller';
+
+describe('AssetsController', () => {
+  let controller: AssetsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AssetsController],
+    }).compile();
+
+    controller = module.get<AssetsController>(AssetsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/assets/assets.controller.ts
+++ b/src/modules/assets/assets.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('assets')
+export class AssetsController {}

--- a/src/modules/assets/assets.entity.ts
+++ b/src/modules/assets/assets.entity.ts
@@ -24,9 +24,10 @@ export class Assets extends BaseEntity {
   @Column({
     type: 'int',
     nullable: false,
+    default: () => '0',
     comment: '상자를 열 수 있는 재화',
   })
-  play_key!: boolean;
+  key!: number;
 
   @CreateDateColumn({
     type: 'timestamp',
@@ -42,7 +43,7 @@ export class Assets extends BaseEntity {
   })
   updated_at!: Date;
 
-  @ManyToOne((type) => Users)
+  @ManyToOne(() => Users)
   @JoinColumn({ name: 'steam_id', referencedColumnName: 'steam_id' })
   users: Users;
 }

--- a/src/modules/assets/assets.entity.ts
+++ b/src/modules/assets/assets.entity.ts
@@ -5,8 +5,8 @@ import {
   Entity,
   CreateDateColumn,
   UpdateDateColumn,
-  ManyToOne,
   JoinColumn,
+  OneToOne,
 } from 'typeorm';
 import { Users } from '../users/users.entity';
 
@@ -43,7 +43,7 @@ export class Assets extends BaseEntity {
   })
   updated_at!: Date;
 
-  @ManyToOne(() => Users)
+  @OneToOne(() => Users)
   @JoinColumn({ name: 'steam_id', referencedColumnName: 'steam_id' })
   users: Users;
 }

--- a/src/modules/assets/assets.module.ts
+++ b/src/modules/assets/assets.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AssetsService } from './assets.service';
+import { AssetsController } from './assets.controller';
+
+@Module({
+  providers: [AssetsService],
+  controllers: [AssetsController]
+})
+export class AssetsModule {}

--- a/src/modules/assets/assets.module.ts
+++ b/src/modules/assets/assets.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { AssetsService } from './assets.service';
 import { AssetsController } from './assets.controller';
+import { Assets } from './assets.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Assets])],
   providers: [AssetsService],
-  controllers: [AssetsController]
+  controllers: [AssetsController],
+  exports: [AssetsService],
 })
 export class AssetsModule {}

--- a/src/modules/assets/assets.service.spec.ts
+++ b/src/modules/assets/assets.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AssetsService } from './assets.service';
+
+describe('AssetsService', () => {
+  let service: AssetsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AssetsService],
+    }).compile();
+
+    service = module.get<AssetsService>(AssetsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/assets/assets.service.ts
+++ b/src/modules/assets/assets.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AssetsService {}

--- a/src/modules/assets/assets.service.ts
+++ b/src/modules/assets/assets.service.ts
@@ -9,7 +9,7 @@ export class AssetsService {
     this.assetsRepository = assetsRepository;
   }
 
-  async create({ steam_id }: { steam_id: string }): Promise<Assets> {
+  async create({ steam_id }: Partial<Assets>): Promise<Assets> {
     const newAssets = this.assetsRepository.create({ steam_id });
     return await this.assetsRepository.save(newAssets);
   }

--- a/src/modules/assets/assets.service.ts
+++ b/src/modules/assets/assets.service.ts
@@ -1,4 +1,16 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Assets } from './assets.entity';
 
 @Injectable()
-export class AssetsService {}
+export class AssetsService {
+  constructor(@InjectRepository(Assets) private assetsRepository: Repository<Assets>) {
+    this.assetsRepository = assetsRepository;
+  }
+
+  async create({ steam_id }: { steam_id: string }): Promise<Assets> {
+    const newAssets = this.assetsRepository.create({ steam_id });
+    return await this.assetsRepository.save(newAssets);
+  }
+}

--- a/src/modules/characters/characters.controller.spec.ts
+++ b/src/modules/characters/characters.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CharactersController } from './characters.controller';
+
+describe('CharactersController', () => {
+  let controller: CharactersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CharactersController],
+    }).compile();
+
+    controller = module.get<CharactersController>(CharactersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/characters/characters.controller.ts
+++ b/src/modules/characters/characters.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('characters')
+export class CharactersController {}

--- a/src/modules/characters/characters.entity.ts
+++ b/src/modules/characters/characters.entity.ts
@@ -15,40 +15,46 @@ export class Characters extends BaseEntity {
   @Column({
     type: 'bool',
     comment: 'HoJin 캐릭터 해금 여부',
+    default: () => 'true',
   })
   hojin!: boolean;
 
   @Column({
     type: 'bool',
     comment: 'Seimei 캐릭터 해금 여부',
+    default: () => 'false',
   })
   seimei!: boolean;
 
   @Column({
     type: 'bool',
     comment: 'Macia 캐릭터 해금 여부',
+    default: () => 'false',
   })
   macia!: boolean;
 
   @Column({
     type: 'bool',
     comment: 'Sinwol 캐릭터 해금 여부',
+    default: () => 'false',
   })
   sinwol!: boolean;
 
   @Column({
     type: 'bool',
     comment: 'SiWoo 캐릭터 해금 여부',
+    default: () => 'false',
   })
   siWoo!: boolean;
 
   @Column({
     type: 'bool',
     comment: 'Ulises 캐릭터 해금 여부',
+    default: () => 'false',
   })
   ulises!: boolean;
 
-  @ManyToOne((type) => Users)
+  @ManyToOne(() => Users)
   @JoinColumn({ name: 'steam_id', referencedColumnName: 'steam_id' })
   users: Users;
 }

--- a/src/modules/characters/characters.module.ts
+++ b/src/modules/characters/characters.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CharactersController } from './characters.controller';
+import { CharactersService } from './characters.service';
+
+@Module({
+  controllers: [CharactersController],
+  providers: [CharactersService],
+})
+export class CharactersModule {}

--- a/src/modules/characters/characters.module.ts
+++ b/src/modules/characters/characters.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { CharactersController } from './characters.controller';
 import { CharactersService } from './characters.service';
+import { Characters } from './characters.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Characters])],
   controllers: [CharactersController],
   providers: [CharactersService],
+  exports: [CharactersService],
 })
 export class CharactersModule {}

--- a/src/modules/characters/characters.service.spec.ts
+++ b/src/modules/characters/characters.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CharactersService } from './characters.service';
+
+describe('CharactersService', () => {
+  let service: CharactersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CharactersService],
+    }).compile();
+
+    service = module.get<CharactersService>(CharactersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/characters/characters.service.ts
+++ b/src/modules/characters/characters.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CharactersService {}

--- a/src/modules/characters/characters.service.ts
+++ b/src/modules/characters/characters.service.ts
@@ -9,8 +9,8 @@ export class CharactersService {
     this.charactersRepository = charactersRepository;
   }
 
-  async create({ steam_id }: { steam_id: string }): Promise<Characters> {
-    const newAssets = this.charactersRepository.create({ steam_id });
-    return await this.charactersRepository.save(newAssets);
+  async create({ steam_id }: Partial<Characters>): Promise<Characters> {
+    const newCharacter = this.charactersRepository.create({ steam_id });
+    return await this.charactersRepository.save(newCharacter);
   }
 }

--- a/src/modules/characters/characters.service.ts
+++ b/src/modules/characters/characters.service.ts
@@ -1,4 +1,16 @@
 import { Injectable } from '@nestjs/common';
+import { Characters } from './characters.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 
 @Injectable()
-export class CharactersService {}
+export class CharactersService {
+  constructor(@InjectRepository(Characters) private charactersRepository: Repository<Characters>) {
+    this.charactersRepository = charactersRepository;
+  }
+
+  async create({ steam_id }: { steam_id: string }): Promise<Characters> {
+    const newAssets = this.charactersRepository.create({ steam_id });
+    return await this.charactersRepository.save(newAssets);
+  }
+}

--- a/src/modules/presets/presets.entity.ts
+++ b/src/modules/presets/presets.entity.ts
@@ -10,56 +10,73 @@ export class Presets extends BaseEntity {
     type: 'varchar',
     comment: '스팀 아이디',
   })
-  steam_id: string;
+  steam_id!: string;
 
   @Column({
     comment: '상위 혼 종류',
     type: 'int',
+    nullable: true,
+    default: () => 'NULL',
   })
-  saint_soul_type!: number;
+  saint_soul_type: number | null;
 
   @Column({
     comment: '하위 soul1 종류',
     type: 'int',
+    nullable: true,
+    default: () => 'NULL',
   })
-  soul1!: number;
+  soul1: number | null;
 
   @Column({
     comment: '하위 soul2 종류',
     type: 'int',
+    nullable: true,
+    default: () => 'NULL',
   })
-  soul2!: number;
+  soul2: number | null;
 
   @Column({
     comment: '하위 soul3 종류',
     type: 'int',
+    nullable: true,
+    default: () => 'NULL',
   })
-  soul3!: number;
+  soul3: number | null;
+
   @Column({
     comment: '하위 soul4 종류',
     type: 'int',
+    nullable: true,
+    default: () => 'NULL',
   })
-  soul4!: number;
+  soul4: number | null;
 
   @Column({
     comment: '하위 soul5 종류',
     type: 'int',
+    nullable: true,
+    default: () => 'NULL',
   })
-  soul5!: number;
+  soul5: number | null;
 
   @Column({
     comment: '하위 soul6 종류',
     type: 'int',
+    nullable: true,
+    default: () => 'NULL',
   })
-  soul6!: number;
+  soul6: number | null;
 
   @Column({
     comment: '캐릭터 이름',
     type: 'varchar',
+    nullable: true,
+    default: () => 'NULL',
   })
-  character!: string;
+  character: string | null;
 
-  @ManyToOne((type) => Users)
+  @ManyToOne(() => Users)
   @JoinColumn({ name: 'steam_id', referencedColumnName: 'steam_id' })
   users: Users;
 }

--- a/src/modules/presets/presets.entity.ts
+++ b/src/modules/presets/presets.entity.ts
@@ -1,5 +1,5 @@
-import { PrimaryGeneratedColumn, Column, BaseEntity, Entity, ManyToOne, JoinColumn } from 'typeorm';
-import { Users } from '../users/users.entity';
+import { PrimaryGeneratedColumn, Column, BaseEntity, Entity, OneToOne, JoinColumn } from 'typeorm';
+import { Users } from '@users/users.entity';
 
 @Entity('presets')
 export class Presets extends BaseEntity {
@@ -76,7 +76,7 @@ export class Presets extends BaseEntity {
   })
   character: string | null;
 
-  @ManyToOne(() => Users)
+  @OneToOne(() => Users)
   @JoinColumn({ name: 'steam_id', referencedColumnName: 'steam_id' })
   users: Users;
 }

--- a/src/modules/presets/presets.service.ts
+++ b/src/modules/presets/presets.service.ts
@@ -5,9 +5,10 @@ import { Repository } from 'typeorm';
 
 @Injectable()
 export class PresetsService {
-  constructor(@InjectRepository(Presets) private presets: Repository<Presets>) {}
+  constructor(@InjectRepository(Presets) private presetRepository: Repository<Presets>) {}
 
-  async create(presets: Partial<Presets>): Promise<Presets> {
-    return this.presets.save(presets);
+  async create({ steam_id }: Partial<Presets>): Promise<Presets> {
+    const newPreset = this.presetRepository.create({ steam_id });
+    return await this.presetRepository.save(newPreset);
   }
 }

--- a/src/modules/reward_boxes/reward_boxes.entity.ts
+++ b/src/modules/reward_boxes/reward_boxes.entity.ts
@@ -59,7 +59,7 @@ export class Reward_boxes extends BaseEntity {
   })
   updated_at!: Date;
 
-  @ManyToOne((type) => Users)
+  @ManyToOne(() => Users)
   @JoinColumn({ name: 'steam_id', referencedColumnName: 'steam_id' })
   users: Users;
 }

--- a/src/modules/saint_souls/saint_souls.controller.spec.ts
+++ b/src/modules/saint_souls/saint_souls.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SaintSoulsController } from './saint_souls.controller';
+
+describe('SaintSoulsController', () => {
+  let controller: SaintSoulsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SaintSoulsController],
+    }).compile();
+
+    controller = module.get<SaintSoulsController>(SaintSoulsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/saint_souls/saint_souls.controller.ts
+++ b/src/modules/saint_souls/saint_souls.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('saint-souls')
+export class SaintSoulsController {}

--- a/src/modules/saint_souls/saint_souls.entity.ts
+++ b/src/modules/saint_souls/saint_souls.entity.ts
@@ -11,7 +11,7 @@ import {
 import { Users } from '../users/users.entity';
 
 @Entity('saint_souls')
-export class Saint_souls extends BaseEntity {
+export class SaintSouls extends BaseEntity {
   @PrimaryGeneratedColumn({ comment: '고유 ID' })
   id: number;
 

--- a/src/modules/saint_souls/saint_souls.entity.ts
+++ b/src/modules/saint_souls/saint_souls.entity.ts
@@ -3,12 +3,12 @@ import {
   Column,
   BaseEntity,
   Entity,
-  ManyToOne,
+  OneToOne,
   CreateDateColumn,
   UpdateDateColumn,
   JoinColumn,
 } from 'typeorm';
-import { Users } from '../users/users.entity';
+import { Users } from '@users/users.entity';
 
 @Entity('saint_souls')
 export class SaintSouls extends BaseEntity {
@@ -70,7 +70,7 @@ export class SaintSouls extends BaseEntity {
   })
   updated_at!: Date;
 
-  @ManyToOne(() => Users)
+  @OneToOne(() => Users)
   @JoinColumn({ name: 'steam_id', referencedColumnName: 'steam_id' })
   users: Users;
 }

--- a/src/modules/saint_souls/saint_souls.entity.ts
+++ b/src/modules/saint_souls/saint_souls.entity.ts
@@ -10,8 +10,8 @@ import {
 } from 'typeorm';
 import { Users } from '../users/users.entity';
 
-@Entity('saint_soul')
-export class Saint_soul extends BaseEntity {
+@Entity('saint_souls')
+export class Saint_souls extends BaseEntity {
   @PrimaryGeneratedColumn({ comment: '고유 ID' })
   id: number;
 
@@ -24,30 +24,35 @@ export class Saint_soul extends BaseEntity {
   @Column({
     comment: '첫 번째 소울 해금상태',
     type: 'bool',
+    default: () => 'true',
   })
   saint_soul1!: boolean;
 
   @Column({
     comment: '두 번째 소울 해금상태',
     type: 'bool',
+    default: () => 'true',
   })
   saint_soul2!: boolean;
 
   @Column({
     comment: '세 번째 소울 해금상태',
     type: 'bool',
+    default: () => 'false',
   })
   saint_soul3!: boolean;
 
   @Column({
     comment: '네 번째 소울 해금상태',
     type: 'bool',
+    default: () => 'false',
   })
   saint_soul4!: boolean;
 
   @Column({
     comment: '다섯 번째 소울 해금상태',
     type: 'bool',
+    default: () => 'false',
   })
   saint_soul5!: boolean;
 
@@ -65,7 +70,7 @@ export class Saint_soul extends BaseEntity {
   })
   updated_at!: Date;
 
-  @ManyToOne((type) => Users)
+  @ManyToOne(() => Users)
   @JoinColumn({ name: 'steam_id', referencedColumnName: 'steam_id' })
   users: Users;
 }

--- a/src/modules/saint_souls/saint_souls.module.ts
+++ b/src/modules/saint_souls/saint_souls.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { SaintSoulsService } from './saint_souls.service';
 import { SaintSoulsController } from './saint_souls.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SaintSouls } from './saint_souls.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([SaintSouls])],
   providers: [SaintSoulsService],
   controllers: [SaintSoulsController],
+  exports: [SaintSoulsService],
 })
 export class SaintSoulsModule {}

--- a/src/modules/saint_souls/saint_souls.module.ts
+++ b/src/modules/saint_souls/saint_souls.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SaintSoulsService } from './saint_souls.service';
+import { SaintSoulsController } from './saint_souls.controller';
+
+@Module({
+  providers: [SaintSoulsService],
+  controllers: [SaintSoulsController],
+})
+export class SaintSoulsModule {}

--- a/src/modules/saint_souls/saint_souls.service.spec.ts
+++ b/src/modules/saint_souls/saint_souls.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SaintSoulsService } from './saint_souls.service';
+
+describe('SaintSoulsService', () => {
+  let service: SaintSoulsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SaintSoulsService],
+    }).compile();
+
+    service = module.get<SaintSoulsService>(SaintSoulsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/saint_souls/saint_souls.service.ts
+++ b/src/modules/saint_souls/saint_souls.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SaintSoulsService {}

--- a/src/modules/saint_souls/saint_souls.service.ts
+++ b/src/modules/saint_souls/saint_souls.service.ts
@@ -1,4 +1,14 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SaintSouls } from './saint_souls.entity';
 
 @Injectable()
-export class SaintSoulsService {}
+export class SaintSoulsService {
+  constructor(@InjectRepository(SaintSouls) private saintSoulsRepogitory: Repository<SaintSouls>) {}
+
+  async create({ steam_id }: Partial<SaintSouls>): Promise<SaintSouls> {
+    const newSaintSoul = this.saintSoulsRepogitory.create({ steam_id });
+    return await this.saintSoulsRepogitory.save(newSaintSoul);
+  }
+}

--- a/src/modules/souls/souls.entity.ts
+++ b/src/modules/souls/souls.entity.ts
@@ -20,6 +20,7 @@ export class Souls extends BaseEntity {
 
   @Column({
     comment: '소울1 조각 개수',
+    default: () => '0',
     type: 'int',
   })
   soul1!: number;
@@ -27,106 +28,123 @@ export class Souls extends BaseEntity {
   @Column({
     comment: '소울2 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul2!: number;
 
   @Column({
     comment: '소울3 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul3!: number;
 
   @Column({
     comment: '소울4 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul4!: number;
 
   @Column({
     comment: '소울5 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul5!: number;
 
   @Column({
     comment: '소울6 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul6!: number;
 
   @Column({
     comment: '소울7 조각 개수',
     type: 'int',
+    default: () => 0,
   })
   soul7!: number;
 
   @Column({
     comment: '소울8 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul8!: number;
 
   @Column({
     comment: '소울9 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul9!: number;
 
   @Column({
     comment: '소울10 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul10!: number;
 
   @Column({
     comment: '소울11 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul11!: number;
 
   @Column({
     comment: '소울12 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul12!: number;
 
   @Column({
     comment: '소울13 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul13!: number;
 
   @Column({
     comment: '소울14 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul14!: number;
 
   @Column({
     comment: '소울15 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul15!: number;
 
   @Column({
     comment: '소울16 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul16!: number;
 
   @Column({
     comment: '소울17 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul17!: number;
 
   @Column({
     comment: '소울18 조각 개수',
     type: 'int',
+    default: () => '0',
   })
   soul18!: number;
 
-  @ManyToOne((type) => Users)
+  @ManyToOne(() => Users)
   @JoinColumn({ name: 'steam_id', referencedColumnName: 'steam_id' })
   users: Users;
 }

--- a/src/modules/souls/souls.module.ts
+++ b/src/modules/souls/souls.module.ts
@@ -13,5 +13,6 @@ import { GlobalValidationPipe } from '@/common/errors/globalValidatiion.pipe';
   imports: [TypeOrmModule.forFeature([Souls])],
   providers: [SoulsService, GlobalHttpExceptionFilter, GlobalValidationPipe],
   controllers: [SoulsController],
+  exports: [SoulsService],
 })
 export class SoulsModule {}

--- a/src/modules/souls/souls.service.ts
+++ b/src/modules/souls/souls.service.ts
@@ -5,9 +5,10 @@ import { Repository } from 'typeorm';
 
 @Injectable()
 export class SoulsService {
-  constructor(@InjectRepository(Souls) private souls: Repository<Souls>) {}
+  constructor(@InjectRepository(Souls) private soulRepogitory: Repository<Souls>) {}
 
-  async create(souls: Partial<Souls>): Promise<Souls> {
-    return this.souls.save(souls);
+  async create({ steam_id, saint_soul_type }: Partial<Souls>): Promise<Souls> {
+    const newSoul = this.soulRepogitory.create({ steam_id, saint_soul_type });
+    return await this.soulRepogitory.save(newSoul);
   }
 }

--- a/src/modules/stages/stages.entity.ts
+++ b/src/modules/stages/stages.entity.ts
@@ -19,21 +19,21 @@ export class Stages extends BaseEntity {
 
   @Column({
     type: 'bool',
-    default: () => false,
+    default: () => 'false',
     comment: '게임 진행 중 여부',
   })
   is_finished!: boolean;
 
   @Column({
     type: 'bool',
-    default: () => false,
+    default: () => 'false',
     comment: '클리어 여부',
   })
   is_clear!: boolean;
 
   @Column({
     type: 'int',
-    default: () => false,
+    default: () => 'false',
     comment: '플레이 시간',
   })
   play_time!: number;

--- a/src/modules/stages/stages.module.ts
+++ b/src/modules/stages/stages.module.ts
@@ -8,8 +8,8 @@ import { DecryptionMiddleware } from './stages.middleware';
 
 import { GlobalHttpExceptionFilter } from '@/common/errors/globalHttpException.filter';
 import { GlobalValidationPipe } from '@/common/errors/globalValidatiion.pipe';
-import { PresetsService } from '../presets/presets.service';
-import { Presets } from '../presets/presets.entity';
+import { PresetsService } from '@/modules/presets/presets.service';
+import { Presets } from '@/modules/presets/presets.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Stages, Presets])],

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,13 +1,18 @@
 import { Controller, Post, Body, HttpStatus, Get, Query } from '@nestjs/common';
+import { ApiQuery } from '@nestjs/swagger';
 
 import { UsersService } from './users.service';
 import { RegisterDto, CheckDuplicatedDto } from './users.dto';
-import { ApiQuery } from '@nestjs/swagger';
+
+import { AssetsService } from '../assets/assets.service';
+
 import { encrypt } from '@utils/security';
+import { DataSource } from 'typeorm';
 
 @Controller('auth')
 export class UsersController {
-  constructor(private usersService: UsersService) {}
+  dataSource: DataSource;
+  constructor(private usersService: UsersService, private assetsService: AssetsService) {}
 
   @ApiQuery({
     name: 'name',
@@ -37,8 +42,22 @@ export class UsersController {
 
   @Post('/regist')
   async createUser(@Body() data: RegisterDto) {
-    const user = await this.usersService.create(data);
-    console.log('in router :: ', user);
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      const userPromise = this.usersService.create(data);
+      const assetPromise = this.assetsService.create({ steam_id: data.steam_id });
+
+      const [user, asset] = await Promise.all([userPromise, assetPromise]);
+
+      console.log('in router :: ', user, asset);
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      throw err;
+    } finally {
+      await queryRunner.release();
+    }
     return {
       statusCode: HttpStatus.OK,
       message: 'User created successfully',

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -7,6 +7,9 @@ import { RegisterDto, CheckDuplicatedDto } from './users.dto';
 
 import { AssetsService } from '../assets/assets.service';
 import { CharactersService } from '../characters/characters.service';
+import { SoulsService } from '@/modules/souls/souls.service';
+import { PresetsService } from '@/modules/presets/presets.service';
+import { SaintSoulsService } from '@/modules/saint_souls/saint_souls.service';
 
 import { encrypt } from '@utils/security';
 
@@ -17,6 +20,9 @@ export class UsersController {
     private usersService: UsersService,
     private assetsService: AssetsService,
     private charactersService: CharactersService,
+    private soulsService: SoulsService,
+    private presetsService: PresetsService,
+    private saintSoulsService: SaintSoulsService,
   ) {}
 
   @ApiQuery({
@@ -47,18 +53,32 @@ export class UsersController {
 
   @Post('/regist')
   async createUser(@Body() data: RegisterDto) {
+    // 트랜잭션 잘 작동 안하는 것 같음. 추후 수정 필요
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
     await queryRunner.startTransaction();
 
     try {
-      const userPromise = this.usersService.create(data);
+      const user = await this.usersService.create(data);
       const assetPromise = this.assetsService.create({ steam_id: data.steam_id });
       const characterPromise = this.charactersService.create({ steam_id: data.steam_id });
+      const soulPromises = [1, 2, 3, 4, 5].map((i) =>
+        this.soulsService.create({ steam_id: data.steam_id, saint_soul_type: i }),
+      );
+      const presetPromise = this.presetsService.create({ steam_id: data.steam_id });
+      const saintSoulPromise = this.saintSoulsService.create({ steam_id: data.steam_id });
 
-      const [user, asset, character] = await Promise.all([userPromise, assetPromise, characterPromise]);
+      const [asset, character, souls, preset, saintSoul] = await Promise.all([
+        assetPromise,
+        characterPromise,
+        ...soulPromises,
+        presetPromise,
+        saintSoulPromise,
+      ]);
 
-      console.log('in router :: ', user, asset, character);
+      console.log('in router :: ', user, asset, character, souls, preset, saintSoul);
+
+      await queryRunner.commitTransaction();
     } catch (err) {
       await queryRunner.rollbackTransaction();
       throw err;

--- a/src/modules/users/users.entity.ts
+++ b/src/modules/users/users.entity.ts
@@ -58,6 +58,6 @@ export class Users extends BaseEntity {
   })
   is_use!: boolean;
 
-  @OneToMany((type) => Users, (users) => users.steam_id)
+  @OneToMany(() => Users, (users) => users.steam_id)
   childSteam_id!: Users[];
 }

--- a/src/modules/users/users.middleware.ts
+++ b/src/modules/users/users.middleware.ts
@@ -3,12 +3,10 @@ import { Request, Response, NextFunction } from 'express';
 
 import { decrypt } from '@/common/utils/security';
 import HttpStatus from '@/common/types/status';
-import * as BodyParser from 'body-parser';
 
 @Injectable()
 export class DecryptionMiddleware implements NestMiddleware {
   use(req: Request, res: Response, next: NextFunction) {
-    BodyParser.raw({ type: '*/*' })(req, res, next);
     const { data } = req.body;
     console.log('in middleware', data);
 

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -3,14 +3,18 @@ import { MiddlewareConsumer, Module, RequestMethod } from '@nestjs/common';
 import { Users } from './users.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+
+import { AssetsService } from '@/modules/assets/assets.service';
+import { Assets } from '@/modules/assets/assets.entity';
+
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DecryptionMiddleware } from './users.middleware';
 import { GlobalHttpExceptionFilter } from '@/common/errors/globalHttpException.filter';
 import { GlobalValidationPipe } from '@/common/errors/globalValidatiion.pipe';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Users])],
-  providers: [UsersService, GlobalHttpExceptionFilter, GlobalValidationPipe],
+  imports: [TypeOrmModule.forFeature([Users, Assets])],
+  providers: [UsersService, AssetsService, GlobalHttpExceptionFilter, GlobalValidationPipe],
   controllers: [UsersController],
 })
 export class UsersModule {

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -4,8 +4,10 @@ import { Users } from './users.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 
-import { AssetsService } from '@/modules/assets/assets.service';
 import { Assets } from '@/modules/assets/assets.entity';
+import { AssetsService } from '@/modules/assets/assets.service';
+import { Characters } from '@/modules/characters/characters.entity';
+import { CharactersService } from '@/modules/characters/characters.service';
 
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DecryptionMiddleware } from './users.middleware';
@@ -13,8 +15,8 @@ import { GlobalHttpExceptionFilter } from '@/common/errors/globalHttpException.f
 import { GlobalValidationPipe } from '@/common/errors/globalValidatiion.pipe';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Users, Assets])],
-  providers: [UsersService, AssetsService, GlobalHttpExceptionFilter, GlobalValidationPipe],
+  imports: [TypeOrmModule.forFeature([Users, Assets, Characters])],
+  providers: [UsersService, AssetsService, CharactersService, GlobalHttpExceptionFilter, GlobalValidationPipe],
   controllers: [UsersController],
 })
 export class UsersModule {

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -5,9 +5,16 @@ import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 
 import { Assets } from '@/modules/assets/assets.entity';
-import { AssetsService } from '@/modules/assets/assets.service';
 import { Characters } from '@/modules/characters/characters.entity';
+import { Souls } from '@/modules/souls/souls.entity';
+import { Presets } from '@/modules/presets/presets.entity';
+import { SaintSouls } from '@/modules/saint_souls/saint_souls.entity';
+
+import { AssetsService } from '@/modules/assets/assets.service';
 import { CharactersService } from '@/modules/characters/characters.service';
+import { SoulsService } from '@/modules/souls/souls.service';
+import { PresetsService } from '@/modules/presets/presets.service';
+import { SaintSoulsService } from '@/modules/saint_souls/saint_souls.service';
 
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DecryptionMiddleware } from './users.middleware';
@@ -15,8 +22,17 @@ import { GlobalHttpExceptionFilter } from '@/common/errors/globalHttpException.f
 import { GlobalValidationPipe } from '@/common/errors/globalValidatiion.pipe';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Users, Assets, Characters])],
-  providers: [UsersService, AssetsService, CharactersService, GlobalHttpExceptionFilter, GlobalValidationPipe],
+  imports: [TypeOrmModule.forFeature([Users, Assets, Characters, Souls, Presets, SaintSouls])],
+  providers: [
+    UsersService,
+    AssetsService,
+    CharactersService,
+    SoulsService,
+    PresetsService,
+    SaintSoulsService,
+    GlobalHttpExceptionFilter,
+    GlobalValidationPipe,
+  ],
   controllers: [UsersController],
 })
 export class UsersModule {


### PR DESCRIPTION
- 회원가입시 생성되었어야 할 다른 테이블 만들기
- assets, characters, presets, saint_souls, souls 테이블은 회원가입시 만들어지고, 차후 업데이트만 되어야함.
- 특히 souls는 saint_soul 하나당 하나씩 있어야하므로 총 5개가 만들어짐
- saint_souls `s`가 안붙어있어서 수정 (그런데 saint_soul 테이블은 계속 만들어짐)
- 트랜잭션으로 중간에 하나라도 안만들어지면 전부 롤백하려했는데 잘 안됨
- 위의 테이블 Many to one으로 되어있는게 있어서 일부 수정 (전부 체크는 안해봄)

[해결한 이슈](https://github.com/I-Need-Mac/ShadowOfMoon-Server/issues/31)

### 실행 화면
<img width="600" alt="스크린샷 2023-05-10 오후 11 53 50" src="https://github.com/I-Need-Mac/ShadowOfMoon-Server/assets/51700274/d5a1752c-1322-4d7e-a943-1243ea036c45">
<img width="600" alt="스크린샷 2023-05-10 오후 11 54 42" src="https://github.com/I-Need-Mac/ShadowOfMoon-Server/assets/51700274/b9ca420d-cad7-4a03-910f-cb312c882fcd">
