### PR TITLE
feat: reward box own api 응답에 서버시간 추가

### DIFF
--- a/src/modules/reward_boxes/reward_boxes.controller.ts
+++ b/src/modules/reward_boxes/reward_boxes.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, HttpStatus, Param, Patch } from '@nestjs/common'
 import { ApiOperation } from '@nestjs/swagger';
 import { RewardBoxesService } from './reward_boxes.service';
 import { FindRewardBoxDto, RewardBoxOpenStartDto, RewardBoxOpenEndDto } from './reward_boxes.dto';
+import * as dayjs from 'dayjs';
 
 @Controller('reward-box')
 export class RewardBoxesController {
@@ -16,7 +17,7 @@ export class RewardBoxesController {
     return {
       statusCode: HttpStatus.OK,
       message: 'find reward box success',
-      data: userRewardBoxes,
+      data: { userRewardBoxes, current_time: dayjs().format() },
     };
   }
 

--- a/src/modules/reward_boxes/reward_boxes.service.ts
+++ b/src/modules/reward_boxes/reward_boxes.service.ts
@@ -67,7 +67,7 @@ export class RewardBoxesService {
     const rewardBox = await this.rewardBoxesRepository.findOne({ where: { id, steam_id } });
     if (!rewardBox) return null;
 
-    rewardBox.open_start_time = new Date();
+    rewardBox.open_start_time = new Date(dayjs().add(9, 'h').format('YYYY-MM-DD HH:mm:ss'));
     return await this.rewardBoxesRepository.save(rewardBox);
   }
 


### PR DESCRIPTION
current_time attribute 로 확인 가능
<img width="646" alt="스크린샷 2024-03-16 오후 6 00 07" src="https://github.com/I-Need-Mac/ShadowOfMoon-Server/assets/51700274/940ab24e-ac47-4c04-99e2-c0439295f7ba">
